### PR TITLE
Fix Hungarian time text conversion and add tests

### DIFF
--- a/ido.py
+++ b/ido.py
@@ -1,54 +1,109 @@
 import datetime
 
-def szam_to_betu(szam):
-    betuk = ["nulla", "egy", "kettő", "három", "négy", "öt", "hat", "hét", "nyolc", "kilenc", "tíz", "tizenegy", "tizenkettő"]
-    if szam <= 12:
-        return betuk[szam]
-    else:
-        return betuk[szam-12]
+
+SZAM_NEVES = {
+    0: "nulla",
+    1: "egy",
+    2: "kettő",
+    3: "három",
+    4: "négy",
+    5: "öt",
+    6: "hat",
+    7: "hét",
+    8: "nyolc",
+    9: "kilenc",
+    10: "tíz",
+    11: "tizenegy",
+    12: "tizenkettő",
+    13: "tizenhárom",
+    14: "tizennégy",
+    15: "tizenöt",
+    16: "tizenhat",
+    17: "tizenhét",
+    18: "tizennyolc",
+    19: "tizenkilenc",
+    20: "húsz",
+    21: "huszonegy",
+    22: "huszonkettő",
+    23: "huszonhárom",
+    24: "huszonnégy",
+    25: "huszonöt",
+    26: "huszonhat",
+    27: "huszonhét",
+    28: "huszonnyolc",
+    29: "huszonkilenc",
+}
+
+
+def szam_to_betu(szam: int) -> str:
+    """Alakítsa át a számot szöveggé a magyar időmondatokhoz."""
+
+    try:
+        return SZAM_NEVES[szam]
+    except KeyError as exc:  # pragma: no cover - programozási hiba esetén
+        raise ValueError(f"Nincs definiálva név a(z) {szam} számhoz.") from exc
+
+
+def ora_to_betu(hour: int) -> str:
+    """Adja vissza az óra szöveges formáját (12 órás formátum)."""
+
+    hour_mod = hour % 12
+    if hour_mod == 0:
+        hour_mod = 12
+    return SZAM_NEVES[hour_mod]
+
+
+def perc_to_betu(szam: int) -> str:
+    """A percekhez illeszkedő alakot ad vissza (két perc, tizenkét perc, stb.)."""
+
+    special_forms = {2: "két", 12: "tizenkét", 22: "huszonkét"}
+    return special_forms.get(szam, szam_to_betu(szam))
 
 def ora_perc_string(dt):
     hour = dt.hour
     minute = dt.minute
-    
+
     if minute == 0:
-        return f"{szam_to_betu(hour)} óra"
-    
+        return f"{ora_to_betu(hour)} óra"
+
     if minute <= 10:
-        return f"{szam_to_betu(hour)} óra {szam_to_betu(minute)}"
-    
+        return f"{ora_to_betu(hour)} óra {szam_to_betu(minute)}"
+
     if minute <= 14:
-        return f"{szam_to_betu(15-minute)} perc múlva negyed {szam_to_betu(hour+1)}"
-    
+        return f"{perc_to_betu(15-minute)} perc múlva negyed {ora_to_betu(hour+1)}"
+
     if minute == 15:
-        return f"negyed {szam_to_betu(hour+1)}"
-    
+        return f"negyed {ora_to_betu(hour+1)}"
+
     if minute <= 20:
-        return f"negyed {szam_to_betu(hour+1)} múlt {szam_to_betu(minute-15)} perccel"
-    
+        return f"negyed {ora_to_betu(hour+1)} múlt {perc_to_betu(minute-15)} perccel"
+
     if minute <= 29:
-        return f"{szam_to_betu(30-minute)} perc múlva fél {szam_to_betu(hour+1)}"
-    
+        return f"{perc_to_betu(30-minute)} perc múlva fél {ora_to_betu(hour+1)}"
+
     if minute == 30:
-        return f"fél {szam_to_betu(hour+1)}"
-    
+        return f"fél {ora_to_betu(hour+1)}"
+
     if minute <= 39:
-        return f"fél {szam_to_betu(hour+1)} múlt {szam_to_betu(minute-30)} perccel"
-    
+        return f"fél {ora_to_betu(hour+1)} múlt {perc_to_betu(minute-30)} perccel"
+
     if minute <= 44:
-        return f"{szam_to_betu(45-minute)} perc múlva háromnegyed {szam_to_betu(hour+1)}"
-    
+        return f"{perc_to_betu(45-minute)} perc múlva háromnegyed {ora_to_betu(hour+1)}"
+
     if minute == 45:
-        return f"háromnegyed {szam_to_betu(hour+1)}"
-    
+        return f"háromnegyed {ora_to_betu(hour+1)}"
+
     if minute <= 49:
-        return f"háromnegyed {szam_to_betu(hour+1)} múlt {szam_to_betu(minute-45)} perccel"
-    
-    return f"{szam_to_betu(60-minute)} perc múlva {szam_to_betu(hour+1)}"
+        return f"háromnegyed {ora_to_betu(hour+1)} múlt {perc_to_betu(minute-45)} perccel"
 
-now = datetime.datetime.now()
-#desired_time = datetime.datetime(now.year, now.month, now.day, 12, 0)  # kívánt idő
-#now = desired_time  # now változó beállítása a kívánt időre
+    return f"{perc_to_betu(60-minute)} perc múlva {ora_to_betu(hour+1)}"
 
-ido_szoveg = ora_perc_string(now)
-print(ido_szoveg)
+
+def main() -> None:
+    now = datetime.datetime.now()
+    ido_szoveg = ora_perc_string(now)
+    print(ido_szoveg)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ido.py
+++ b/tests/test_ido.py
@@ -1,0 +1,31 @@
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ido import ora_perc_string
+
+
+@pytest.mark.parametrize(
+    "dt, expected",
+    [
+        (datetime.datetime(2023, 1, 1, 0, 0), "tizenkettő óra"),
+        (datetime.datetime(2023, 1, 1, 13, 0), "egy óra"),
+        (datetime.datetime(2023, 1, 1, 1, 5), "egy óra öt"),
+        (datetime.datetime(2023, 1, 1, 1, 14), "egy perc múlva negyed kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 15), "negyed kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 20), "negyed kettő múlt öt perccel"),
+        (datetime.datetime(2023, 1, 1, 1, 29), "egy perc múlva fél kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 30), "fél kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 35), "fél kettő múlt öt perccel"),
+        (datetime.datetime(2023, 1, 1, 1, 44), "egy perc múlva háromnegyed kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 45), "háromnegyed kettő"),
+        (datetime.datetime(2023, 1, 1, 1, 47), "háromnegyed kettő múlt két perccel"),
+        (datetime.datetime(2023, 1, 1, 1, 58), "két perc múlva kettő"),
+    ],
+)
+def test_ora_perc_string(dt, expected):
+    assert ora_perc_string(dt) == expected


### PR DESCRIPTION
## Summary
- replace the simplistic number-to-text logic with explicit Hungarian names and hour/minute helpers
- ensure minute phrases use the correct linguistic forms (két, tizenkét, huszonkét) when building sentences
- add pytest coverage for typical edge cases of the time-string generator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ee518131048328ba947ef8e729d3f2