### PR TITLE
Refine Gym iPhone UI and preload sample exercise

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,73 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Gym",
+    defaultLocalization: "hu",
+    platforms: [
+        .iOS(.v17),
+        .watchOS(.v10)
+    ],
+    products: [
+        .library(name: "GymDomain", targets: ["Domain"]),
+        .library(name: "GymPersistence", targets: ["Persistence"]),
+        .library(name: "GymHealth", targets: ["Health"]),
+        .library(name: "GymAI", targets: ["AICore"]),
+        .executable(name: "GymApp", targets: ["App"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.26.0")
+    ],
+    targets: [
+        .target(
+            name: "Domain",
+            dependencies: [],
+            path: "Sources/Domain"
+        ),
+        .target(
+            name: "Persistence",
+            dependencies: [
+                "Domain",
+                .product(name: "GRDB", package: "GRDB.swift")
+            ],
+            path: "Sources/Persistence",
+            resources: [
+                .process("Migrations")
+            ]
+        ),
+        .target(
+            name: "Health",
+            dependencies: [
+                "Domain"
+            ],
+            path: "Sources/Health"
+        ),
+        .target(
+            name: "AICore",
+            dependencies: [
+                "Domain"
+            ],
+            path: "Sources/AI"
+        ),
+        .target(
+            name: "AppIntents",
+            dependencies: ["Domain", "Persistence", "AICore"],
+            path: "Sources/AppIntents"
+        ),
+        .target(
+            name: "WatchApp",
+            dependencies: ["Domain", "Persistence", "Health"],
+            path: "Sources/WatchApp"
+        ),
+        .executableTarget(
+            name: "App",
+            dependencies: ["Domain", "Persistence", "Health", "AICore", "AppIntents"],
+            path: "Sources/App"
+        ),
+        .testTarget(
+            name: "GymTests",
+            dependencies: ["Domain", "Persistence", "AICore"],
+            path: "Tests/GymTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Gym – Offline edzésnapló és AI edző iOS-re
+
+A Gym egy SwiftUI-alapú, teljesen offline működő edzésnapló és AI edző. A projekt moduláris felépítésben tartalmazza a fő alkalmazást, a tartományi réteget, a perzisztenciát, az AI modult és a watchOS kísérő alkalmazást.
+
+## Fő funkciók
+- **Edzésnaplózás**: Gyakorlatok, szettek, súlyok és RPE értékek rögzítése, sablonok kezelése.
+- **Haladás-követés**: Összesített volumen, izomcsoport eloszlások és testsúly trendek számítása.
+- **AI Edző**: Lokális elemzések és nyelvi generálás a személyre szabott visszajelzésekhez.
+- **watchOS támogatás**: Pulzuskövetés és edzésindítás közvetlenül az óráról.
+- **Ajánlott gyakorlat**: Alapértelmezetten elérhető az „Egykezes mellnyomás fekve” leírással, videóval és animált demonstrációval.
+
+## Modulok
+- `Domain`: Entitások, érték objektumok és use case-ek.
+- `Persistence`: GRDB-alapú SQLite perzisztencia, repository implementációk.
+- `Health`: HealthKit integrációs kapu.
+- `AICore`: Offline AI elemzés és nyelvi generálás.
+- `App`: SwiftUI felhasználói felület és view modellek.
+- `WatchApp`: watchOS workout session kezelése.
+- `AppIntents`: Siri Shortcut / App Intent integráció.
+
+## Fejlesztés
+A projekt Swift Package Managerrel szervezett. A modulok Xcode-ban importálhatók, a `GymApp` cél SwiftUI alkalmazásként futtatható iOS 17+ rendszeren.
+
+```bash
+swift package resolve
+```
+
+A tesztek futtatása:
+
+```bash
+swift test
+```
+
+## Adatvédelem
+Minden adat a készüléken, lokális SQLite adatbázisban tárolódik, nincs hálózati kommunikáció. Az opcionális ChatGPT integráció csak explicit konfiguráció után érhető el.

--- a/Sources/AI/Offline/OfflineAIRecommender.swift
+++ b/Sources/AI/Offline/OfflineAIRecommender.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Domain
+
+public final class OfflineAIRecommender: AIRecommender {
+    private let trendAnalyzer: TrendAnalyzer
+    private let languageGenerator: LanguageGenerator
+
+    public init(
+        trendAnalyzer: TrendAnalyzer = TrendAnalyzer(),
+        languageGenerator: LanguageGenerator = LanguageGenerator()
+    ) {
+        self.trendAnalyzer = trendAnalyzer
+        self.languageGenerator = languageGenerator
+    }
+
+    public func generateInsight(for workout: Workout, history: [Workout], metrics: [BodyMetric]) async throws -> AIInsight {
+        let trend = trendAnalyzer.makeTrend(for: workout, history: history, metrics: metrics)
+        let texts = try await languageGenerator.generateMessages(for: trend)
+        return AIInsight(
+            workoutID: workout.id,
+            motivationText: texts.motivation,
+            recommendationText: texts.recommendation,
+            tags: texts.tags,
+            appliedChanges: texts.changes
+        )
+    }
+}
+
+public struct WorkoutTrend {
+    public let workout: Workout
+    public let progressiveOverloadScore: Double
+    public let fatigueScore: Double
+    public let muscleBalance: [MuscleGroup: Double]
+    public let averageHeartRate: Double
+    public let maxHeartRate: Double
+    public let weightTrend: Double?
+}
+
+public final class TrendAnalyzer {
+    public init() {}
+
+    public func makeTrend(for workout: Workout, history: [Workout], metrics: [BodyMetric]) -> WorkoutTrend {
+        let progressiveScore = Self.progressionScore(for: workout, history: history)
+        let fatigueScore = Self.fatigueScore(for: history + [workout])
+        let muscleBalance = Self.balance(for: history + [workout])
+        let weightTrend = Self.weightTrend(metrics: metrics)
+        return WorkoutTrend(
+            workout: workout,
+            progressiveOverloadScore: progressiveScore,
+            fatigueScore: fatigueScore,
+            muscleBalance: muscleBalance,
+            averageHeartRate: workout.averageHeartRate ?? 0,
+            maxHeartRate: workout.maxHeartRate ?? 0,
+            weightTrend: weightTrend
+        )
+    }
+
+    private static func progressionScore(for workout: Workout, history: [Workout]) -> Double {
+        let similar = history.filter { $0.date < workout.date && !$0.entries.isEmpty }
+        guard let last = similar.sorted(by: { $0.date > $1.date }).first else { return 1 }
+        return workout.volume / max(last.volume, 1)
+    }
+
+    private static func fatigueScore(for workouts: [Workout]) -> Double {
+        let lastWeek = workouts.filter { workout in
+            guard let diff = Calendar.current.dateComponents([.day], from: workout.date, to: Date()).day else { return false }
+            return diff <= 7
+        }
+        let totalSets = lastWeek.reduce(0) { $0 + $1.totalSets }
+        return Double(totalSets) / 100.0
+    }
+
+    private static func balance(for workouts: [Workout]) -> [MuscleGroup: Double] {
+        workouts.reduce(into: [:]) { partialResult, workout in
+            workout.entries.forEach { entry in
+                let volume = entry.totalVolume
+                entry.exercise.primaryMuscles.forEach { partialResult[$0, default: 0] += volume }
+            }
+        }
+    }
+
+    private static func weightTrend(metrics: [BodyMetric]) -> Double? {
+        guard metrics.count >= 2 else { return nil }
+        let sorted = metrics.sorted { $0.date < $1.date }
+        guard let first = sorted.first, let last = sorted.last else { return nil }
+        return (last.value - first.value) / Double(sorted.count)
+    }
+}
+
+public final class LanguageGenerator {
+    public struct Result {
+        public let motivation: String
+        public let recommendation: String
+        public let tags: [AIInsight.InsightKind]
+        public let changes: [RoutineChange]
+    }
+
+    public init() {}
+
+    public func generateMessages(for trend: WorkoutTrend) async throws -> Result {
+        var tags: [AIInsight.InsightKind] = [.motivation, .recommendation]
+        var changes: [RoutineChange] = []
+        var recommendation = ""
+
+        if trend.progressiveOverloadScore < 0.95 {
+            tags.append(.warning)
+            recommendation += "Koncentrálj a fokozatos terhelésre: növeld a kulcs gyakorlatok súlyát 2-2,5 kg-mal. "
+            changes.append(RoutineChange(description: "Növeld a fő emelés súlyát 2,5 kg-mal", changeKind: .increaseWeight))
+        } else {
+            recommendation += "Fenntartsd az előző edzés intenzitását, próbálj meg +1 ismétlést beépíteni. "
+            changes.append(RoutineChange(description: "Adj hozzá egy ismétlést az utolsó szettekhez", changeKind: .increaseReps))
+        }
+
+        if trend.fatigueScore > 0.9 {
+            tags.append(.deloadSuggestion)
+            recommendation += "A magas szettszám miatt javasolt egy deload hét beiktatása. "
+            changes.append(RoutineChange(description: "Tervezett deload hét 50%-os volumen csökkentéssel", changeKind: .scheduleDeload))
+        }
+
+        let motivation = "Remek munka! Az átlagpulzusod \(Int(trend.averageHeartRate)) bpm, a csúcs \(Int(trend.maxHeartRate)) bpm volt."
+
+        return Result(
+            motivation: motivation,
+            recommendation: recommendation.trimmingCharacters(in: .whitespaces),
+            tags: tags,
+            changes: changes
+        )
+    }
+}

--- a/Sources/AI/Online/ChatGPTClient.swift
+++ b/Sources/AI/Online/ChatGPTClient.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Domain
+
+public final class ChatGPTClient {
+    public struct Configuration {
+        public var endpoint: URL
+        public var apiKey: String
+        public init(endpoint: URL, apiKey: String) {
+            self.endpoint = endpoint
+            self.apiKey = apiKey
+        }
+    }
+
+    private let configuration: Configuration
+    private let urlSession: URLSession
+
+    public init(configuration: Configuration, urlSession: URLSession = .shared) {
+        self.configuration = configuration
+        self.urlSession = urlSession
+    }
+
+    public func generateText(from trend: WorkoutTrend) async throws -> (motivation: String, recommendation: String) {
+        var request = URLRequest(url: configuration.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        let payload: [String: Any] = [
+            "model": "gpt-4o-mini",
+            "messages": [
+                [
+                    "role": "system",
+                    "content": "You are a strength coach who responds in Hungarian."
+                ],
+                [
+                    "role": "user",
+                    "content": prompt(for: trend)
+                ]
+            ]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        let result = try JSONDecoder().decode(OpenAIResponse.self, from: data)
+        guard let choice = result.choices.first else { throw URLError(.cannotDecodeRawData) }
+        let text = choice.message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = text.components(separatedBy: "\n\n")
+        let motivation = parts.first ?? text
+        let recommendation = parts.dropFirst().joined(separator: "\n\n")
+        return (motivation, recommendation)
+    }
+
+    private func prompt(for trend: WorkoutTrend) -> String {
+        """
+        Elemezd a következő edzésadatokat és adj motiváló visszajelzést, valamint konkrét javaslatot a progresszív túlterheléshez.
+        Volume trend: \(trend.progressiveOverloadScore)
+        Fatigue score: \(trend.fatigueScore)
+        Izomcsoport megoszlás: \(trend.muscleBalance.map { "\($0.key.localizedName): \($0.value)" }.joined(separator: ", "))
+        Pulzus átlag: \(trend.averageHeartRate)
+        Pulzus csúcs: \(trend.maxHeartRate)
+        Testsúly trend: \(trend.weightTrend ?? 0)
+        Válaszolj strukturáltan két bekezdésben: 1) motiváció 2) ajánlás.
+        """
+    }
+}
+
+private struct OpenAIResponse: Decodable {
+    struct Choice: Decodable {
+        struct Message: Decodable {
+            let role: String
+            let content: String
+        }
+        let index: Int
+        let message: Message
+    }
+    let choices: [Choice]
+}

--- a/Sources/App/Features/AICoach/AICoachView.swift
+++ b/Sources/App/Features/AICoach/AICoachView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import Domain
+
+struct AICoachView: View {
+    @EnvironmentObject private var viewModel: AICoachViewModel
+    @EnvironmentObject private var workoutViewModel: WorkoutLoggingViewModel
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 24) {
+                    if let insight = viewModel.insight {
+                        GymCard(title: "Legutóbbi elemzés", icon: "sparkles") {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text(insight.motivationText)
+                                    .font(.headline)
+                                Text(insight.recommendationText)
+                                    .font(.body)
+                                    .foregroundStyle(.secondary)
+                                Divider()
+                                TagCloud(tags: insight.tags)
+                            }
+                        }
+                    } else {
+                        GymCard(title: "Még nincs elemzés", icon: "sparkles") {
+                            Text("Válassz ki egy edzést a naplóból, majd generálj AI visszajelzést.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    GymCard(title: "AI műveletek", icon: "wand.and.rays") {
+                        VStack(spacing: 16) {
+                            Button {
+                                let workout = workoutViewModel.activeWorkout
+                                guard !workout.entries.isEmpty else { return }
+                                viewModel.generate(for: workout)
+                            } label: {
+                                Label("AI értékelés készítése", systemImage: viewModel.isLoading ? "hourglass" : "wand.and.stars")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(viewModel.isLoading || workoutViewModel.activeWorkout.entries.isEmpty)
+
+                            Text("Az AI az aktuális edzésedet elemzi, és javaslatot készít a következő alkalomra.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+            }
+            .background(
+                LinearGradient(colors: [Color(.systemBackground), Color(.secondarySystemBackground)], startPoint: .top, endPoint: .bottomTrailing)
+                    .ignoresSafeArea()
+            )
+            .navigationTitle("AI Edző")
+        }
+    }
+}

--- a/Sources/App/Features/AICoach/AICoachViewModel.swift
+++ b/Sources/App/Features/AICoach/AICoachViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Domain
+
+@MainActor
+final class AICoachViewModel: ObservableObject {
+    @Published private(set) var insight: AIInsight?
+    @Published private(set) var isLoading = false
+
+    private let generateAIInsightUseCase: GenerateAIInsightUseCase
+
+    init(generateAIInsightUseCase: GenerateAIInsightUseCase) {
+        self.generateAIInsightUseCase = generateAIInsightUseCase
+    }
+
+    func generate(for workout: Workout) {
+        Task {
+            guard !isLoading else { return }
+            isLoading = true
+            defer { isLoading = false }
+            do {
+                insight = try await generateAIInsightUseCase.execute(for: workout)
+            } catch {
+                print("Insight generation failed: \(error)")
+            }
+        }
+    }
+}

--- a/Sources/App/Features/Dashboard/DashboardView.swift
+++ b/Sources/App/Features/Dashboard/DashboardView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import Domain
+
+struct DashboardView: View {
+    @EnvironmentObject private var viewModel: DashboardViewModel
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 24) {
+                    insightSection
+                    upcomingRoutineSection
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+            }
+            .background(
+                LinearGradient(colors: [Color(.systemBackground), Color(.secondarySystemBackground)], startPoint: .top, endPoint: .bottomTrailing)
+                    .ignoresSafeArea()
+            )
+            .navigationTitle("Gym")
+            .toolbar {
+                Button(action: { Task { await viewModel.refresh() } }) {
+                    Image(systemName: viewModel.isLoading ? "hourglass" : "arrow.clockwise")
+                }
+                .disabled(viewModel.isLoading)
+            }
+            .task { viewModel.onAppear() }
+        }
+    }
+
+    private var insightSection: some View {
+        GymCard(title: "AI Edző", icon: "brain.head.profile") {
+            if let insight = viewModel.latestInsight {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(insight.motivationText)
+                        .font(.title3.bold())
+                    Text(insight.recommendationText)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                    Divider()
+                    TagCloud(tags: insight.tags)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Még nincs értékelés")
+                        .font(.headline)
+                    Text("Rögzíts egy edzést, hogy az AI visszajelzést adhasson.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var upcomingRoutineSection: some View {
+        GymCard(title: "Következő edzés", icon: "calendar") {
+            if let routine = viewModel.upcomingRoutine {
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(routine.name)
+                            .font(.title3.bold())
+                        Text(routine.description)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach(routine.dayPlans) { day in
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(day.name)
+                                    .font(.headline)
+                                Spacer()
+                                Text(day.muscleFocus.map(\.localizedName).joined(separator: ", "))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            ForEach(day.exercises) { exercise in
+                                HStack(alignment: .center, spacing: 12) {
+                                    Image(systemName: "dumbbell")
+                                        .foregroundStyle(.accent)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(exercise.name)
+                                            .font(.subheadline)
+                                        if let guidance = exercise.guidance {
+                                            Text(guidance.setSummaryText)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                                    Spacer()
+                                }
+                            }
+                        }
+                        .padding(14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(Color(.tertiarySystemBackground))
+                        )
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Még nincs tervezett edzés")
+                        .font(.headline)
+                    Text("Az AI Edző az aktivitásod alapján ajánl majd rutint.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/Sources/App/Features/Dashboard/DashboardViewModel.swift
+++ b/Sources/App/Features/Dashboard/DashboardViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Domain
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published private(set) var latestInsight: AIInsight?
+    @Published private(set) var upcomingRoutine: Routine?
+    @Published private(set) var isLoading = false
+
+    private let workoutRepository: WorkoutRepository
+    private let aiInsightRepository: AIInsightRepository
+
+    init(workoutRepository: WorkoutRepository, aiInsightRepository: AIInsightRepository) {
+        self.workoutRepository = workoutRepository
+        self.aiInsightRepository = aiInsightRepository
+    }
+
+    func onAppear() {
+        Task { await refresh() }
+    }
+
+    func refresh() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            latestInsight = try await aiInsightRepository.latestInsight()
+            let now = Date()
+            let interval = DateInterval(start: Calendar.current.startOfDay(for: now), end: Calendar.current.date(byAdding: .day, value: 7, to: now) ?? now)
+            let workouts = try await workoutRepository.workouts(between: interval.start, and: interval.end)
+            upcomingRoutine = workouts.first?.entries.first?.exercise.kind == .cardio ? nil : workouts.first?.entries.first.map { entry in
+                Routine(name: "Következő edzés", description: "Automatikus előrejelzés", dayPlans: [Routine.DayPlan(name: "Dinamikus nap", muscleFocus: entry.exercise.primaryMuscles, exercises: [entry.exercise])])
+            }
+        } catch {
+            print("Dashboard refresh failed: \(error)")
+        }
+    }
+}

--- a/Sources/App/Features/Progress/ProgressViewModel.swift
+++ b/Sources/App/Features/Progress/ProgressViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Domain
+
+@MainActor
+final class ProgressViewModel: ObservableObject {
+    @Published private(set) var summary: ProgressSummary?
+    @Published private(set) var isLoading = false
+
+    private let fetchProgressSummaryUseCase: FetchProgressSummaryUseCase
+
+    init(fetchProgressSummaryUseCase: FetchProgressSummaryUseCase) {
+        self.fetchProgressSummaryUseCase = fetchProgressSummaryUseCase
+    }
+
+    func refresh() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let now = Date()
+            let interval = DateInterval(start: Calendar.current.date(byAdding: .month, value: -1, to: now) ?? now, end: now)
+            summary = try await fetchProgressSummaryUseCase.execute(for: interval)
+        } catch {
+            print("Progress refresh failed: \(error)")
+        }
+    }
+}

--- a/Sources/App/Features/Progress/ProgressViewScreen.swift
+++ b/Sources/App/Features/Progress/ProgressViewScreen.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import Domain
+
+struct ProgressViewScreen: View {
+    @EnvironmentObject private var viewModel: ProgressViewModel
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 24) {
+                    if let summary = viewModel.summary {
+                        GymCard(title: "Összkép", icon: "chart.bar.xaxis") {
+                            VStack(alignment: .leading, spacing: 12) {
+                                ProgressSummaryRow(title: "Edzések", value: "\(summary.workoutCount)")
+                                ProgressSummaryRow(title: "Teljes volumen", value: "\(Int(summary.totalVolume)) kg")
+                                ProgressSummaryRow(title: "Átlag intenzitás", value: String(format: "%.1f kg/szett", summary.averageIntensity))
+                                if let weight = summary.latestWeight {
+                                    ProgressSummaryRow(title: "Legfrissebb testsúly", value: String(format: "%.1f kg", weight))
+                                }
+                            }
+                        }
+
+                        GymCard(title: "Izomcsoport eloszlás", icon: "figure.core.training") {
+                            VStack(alignment: .leading, spacing: 8) {
+                                ForEach(summary.volumeByMuscleGroup.sorted(by: { $0.key.localizedName < $1.key.localizedName }), id: \.key) { entry in
+                                    HStack {
+                                        Text(entry.key.localizedName)
+                                        Spacer()
+                                        Text("\(Int(entry.value)) kg")
+                                            .fontWeight(.semibold)
+                                    }
+                                    .padding(.vertical, 6)
+                                    Divider()
+                                }
+                            }
+                        }
+                    } else {
+                        GymCard(title: "Nincs adat", icon: "chart.line.downtrend.xyaxis") {
+                            Text("Rögzíts edzéseket a statisztikák megjelenítéséhez.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+            }
+            .background(
+                LinearGradient(colors: [Color(.systemBackground), Color(.secondarySystemBackground)], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    .ignoresSafeArea()
+            )
+            .navigationTitle("Haladás")
+            .toolbar {
+                Button(action: { Task { await viewModel.refresh() } }) {
+                    Image(systemName: viewModel.isLoading ? "hourglass" : "arrow.clockwise")
+                }
+                .disabled(viewModel.isLoading)
+            }
+            .task { await viewModel.refresh() }
+        }
+    }
+}
+
+private struct ProgressSummaryRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.subheadline)
+            Spacer()
+            Text(value)
+                .font(.headline)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Sources/App/Features/WorkoutLogging/WorkoutLoggingView.swift
+++ b/Sources/App/Features/WorkoutLogging/WorkoutLoggingView.swift
@@ -1,0 +1,448 @@
+import SwiftUI
+import Domain
+
+struct WorkoutLoggingView: View {
+    @EnvironmentObject private var viewModel: WorkoutLoggingViewModel
+    @State private var showingRoutinePicker = false
+    @State private var selectedExercise: Exercise?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 24) {
+                    heroCard
+                    featuredSection
+                    activeWorkoutSection
+                    summarySection
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(
+                LinearGradient(colors: [Color(.systemBackground), Color.accentColor.opacity(0.12)], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    .ignoresSafeArea()
+            )
+            .navigationTitle("Edzés rögzítése")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Sablon") { showingRoutinePicker = true }
+                        .font(.callout.weight(.semibold))
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        viewModel.save()
+                    } label: {
+                        if viewModel.isSaving {
+                            ProgressView()
+                        } else {
+                            Text("Mentés")
+                                .fontWeight(.semibold)
+                        }
+                    }
+                    .disabled(viewModel.isSaving)
+                }
+            }
+            .sheet(isPresented: $showingRoutinePicker) {
+                RoutinePickerView(isPresented: $showingRoutinePicker)
+                    .environmentObject(viewModel)
+            }
+            .sheet(item: $selectedExercise) { exercise in
+                ExerciseDetailSheet(exercise: exercise) {
+                    viewModel.addExerciseFromCatalog(exercise)
+                }
+                .presentationDetents([.medium, .large])
+            }
+            .alert("Mentési hiba", isPresented: Binding(get: { viewModel.saveError != nil }, set: { _ in viewModel.saveError = nil })) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(viewModel.saveError ?? "Ismeretlen hiba")
+            }
+        }
+    }
+
+    private var heroCard: some View {
+        GymCard(title: "Napi edzés", icon: "sparkles.rectangle.stack") {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Egyetlen érintéssel rögzítheted a szetteket, miközben az AI és a statisztikák folyamatosan követik a fejlődésed.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 16) {
+                    metricTile(title: "Össztérfogat", value: "\(Int(viewModel.activeWorkout.volume)) kg")
+                    metricTile(title: "Szett", value: "\(viewModel.activeWorkout.totalSets)")
+                }
+            }
+        }
+    }
+
+    private var featuredSection: some View {
+        GymCard(title: "Ajánlott gyakorlat", icon: "flame.fill") {
+            if viewModel.featuredExercises.isEmpty {
+                Text("Hamarosan új gyakorlatok érkeznek.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 16) {
+                        ForEach(viewModel.featuredExercises) { exercise in
+                            ExercisePreviewCard(exercise: exercise, onInfo: {
+                                selectedExercise = exercise
+                            }, onAdd: {
+                                viewModel.addExerciseFromCatalog(exercise)
+                            })
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    private var activeWorkoutSection: some View {
+        GymCard(title: "Aktív napló", icon: "list.bullet.rectangle") {
+            if viewModel.activeWorkout.entries.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Kezdj az ajánlott gyakorlattal, vagy válassz sablont a bal felső sarokban.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(spacing: 16) {
+                    ForEach(viewModel.activeWorkout.entries) { entry in
+                        WorkoutEntryCard(entry: entry) {
+                            viewModel.addRecommendedSet(to: entry.id)
+                        } onRemove: {
+                            viewModel.removeEntry(entry.id)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var summarySection: some View {
+        GymCard(title: "Összesítés", icon: "sum") {
+            VStack(alignment: .leading, spacing: 12) {
+                summaryRow(title: "Térfogat", value: "\(Int(viewModel.activeWorkout.volume)) kg", icon: "dumbbell.fill")
+                summaryRow(title: "Szett szám", value: "\(viewModel.activeWorkout.totalSets)", icon: "list.number")
+                summaryRow(title: "Célzott izmok", value: viewModel.activeWorkout.musclesTargeted.map(\.localizedName).joined(separator: ", "), icon: "figure.strengthtraining.traditional")
+            }
+        }
+    }
+
+    private func metricTile(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.accentColor.opacity(0.12))
+        )
+    }
+
+    private func summaryRow(title: String, value: String, icon: String) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.callout)
+                Text(value.isEmpty ? "-" : value)
+                    .font(.headline)
+            }
+            Spacer()
+        }
+    }
+}
+
+private struct RoutinePickerView: View {
+    @Binding var isPresented: Bool
+    @EnvironmentObject var viewModel: WorkoutLoggingViewModel
+    @State private var routines: [Routine] = []
+
+    var body: some View {
+        NavigationStack {
+            List(routines) { routine in
+                Button {
+                    viewModel.applyRoutine(routine)
+                    isPresented = false
+                } label: {
+                    VStack(alignment: .leading) {
+                        Text(routine.name)
+                            .font(.headline)
+                        Text(routine.description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Rutinválasztó")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Mégse") { isPresented = false }
+                }
+            }
+            .task {
+                do {
+                    routines = try await viewModel.availableRoutines()
+                } catch {
+                    print("Routine fetch error: \(error)")
+                }
+            }
+        }
+    }
+}
+
+private struct ExercisePreviewCard: View {
+    let exercise: Exercise
+    let onInfo: () -> Void
+    let onAdd: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let mediaURL = exercise.guidance?.mediaURL {
+                AsyncImage(url: mediaURL) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                            .frame(maxWidth: .infinity, minHeight: 120)
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(height: 140)
+                            .clipped()
+                            .cornerRadius(16)
+                    case .failure:
+                        placeholderMedia
+                    @unknown default:
+                        placeholderMedia
+                    }
+                }
+            } else {
+                placeholderMedia
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(exercise.name)
+                    .font(.headline)
+                if let guidance = exercise.guidance {
+                    Text(guidance.setSummaryText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Button(action: onInfo) {
+                        Label("Részletek", systemImage: "info.circle")
+                            .font(.caption)
+                    }
+                    Spacer()
+                    Button(action: onAdd) {
+                        Label("Hozzáad", systemImage: "plus.circle.fill")
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(16)
+        .frame(width: 220)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.secondarySystemBackground).opacity(0.9))
+        )
+    }
+
+    private var placeholderMedia: some View {
+        RoundedRectangle(cornerRadius: 16)
+            .fill(Color.accentColor.opacity(0.1))
+            .overlay(
+                Image(systemName: "dumbbell")
+                    .font(.largeTitle)
+                    .foregroundStyle(.accent)
+            )
+            .frame(height: 140)
+    }
+}
+
+private struct WorkoutEntryCard: View {
+    let entry: WorkoutEntry
+    let onAddSet: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(entry.exercise.name)
+                        .font(.headline)
+                    Text(entry.exercise.primaryMuscles.map(\.localizedName).joined(separator: ", "))
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(action: onRemove) {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.borderless)
+            }
+
+            if let guidance = entry.exercise.guidance {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Ajánlás")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                    Text("Súly: \(guidance.recommendedWeightText)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(guidance.setSummaryText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(entry.sets) { set in
+                    HStack {
+                        Text("\(Int(set.weight)) kg")
+                            .fontWeight(.semibold)
+                        Spacer()
+                        Text("\(set.reps) ismétlés")
+                        if let rpe = set.rpe {
+                            Spacer()
+                            Text("RPE \(String(format: "%.1f", rpe))")
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color(.tertiarySystemBackground))
+                    )
+                }
+            }
+
+            HStack {
+                Button(action: onAddSet) {
+                    Label("Új szett", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+
+                if let url = entry.exercise.guidance?.videoURL {
+                    Spacer()
+                    Link(destination: url) {
+                        Label("Videó", systemImage: "play.rectangle")
+                    }
+                }
+            }
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color(.systemBackground))
+                .shadow(color: Color.black.opacity(0.06), radius: 12, x: 0, y: 6)
+        )
+    }
+}
+
+private struct ExerciseDetailSheet: View {
+    let exercise: Exercise
+    let onAdd: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if let mediaURL = exercise.guidance?.mediaURL {
+                        AsyncImage(url: mediaURL) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                                    .frame(maxWidth: .infinity, minHeight: 200)
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxWidth: .infinity)
+                                    .cornerRadius(24)
+                            case .failure:
+                                placeholder
+                            @unknown default:
+                                placeholder
+                            }
+                        }
+                    } else {
+                        placeholder
+                    }
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(exercise.name)
+                            .font(.title2.bold())
+                        if let guidance = exercise.guidance {
+                            Text("Cél: \(guidance.goal)")
+                                .font(.body)
+                            Text("Súly: \(guidance.recommendedWeightText)")
+                                .font(.body)
+                            Text("Sorozat: \(guidance.setSummaryText)")
+                                .font(.body)
+                            Text(guidance.detailedDescription)
+                                .font(.body)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let instructions = exercise.instructions {
+                            Divider()
+                            Text(instructions)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if let videoURL = exercise.guidance?.videoURL {
+                        Link(destination: videoURL) {
+                            Label("Youtube videó megnyitása", systemImage: "play.rectangle.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+                .padding(24)
+            }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .navigationTitle("Gyakorlat")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Hozzáadás") {
+                        onAdd()
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Bezárás") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var placeholder: some View {
+        RoundedRectangle(cornerRadius: 24)
+            .fill(Color.accentColor.opacity(0.1))
+            .frame(maxWidth: .infinity, minHeight: 200)
+            .overlay(
+                Image(systemName: "dumbbell.fill")
+                    .font(.largeTitle)
+                    .foregroundStyle(.accent)
+            )
+    }
+}

--- a/Sources/App/Features/WorkoutLogging/WorkoutLoggingViewModel.swift
+++ b/Sources/App/Features/WorkoutLogging/WorkoutLoggingViewModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Domain
+
+@MainActor
+final class WorkoutLoggingViewModel: ObservableObject {
+    @Published var activeWorkout: Workout
+    @Published var isSaving = false
+    @Published var saveError: String?
+    @Published var featuredExercises: [Exercise]
+
+    private let logWorkoutUseCase: LogWorkoutUseCase
+    private let routineRepository: RoutineRepository
+
+    init(logWorkoutUseCase: LogWorkoutUseCase, routineRepository: RoutineRepository) {
+        self.logWorkoutUseCase = logWorkoutUseCase
+        self.routineRepository = routineRepository
+        activeWorkout = Workout(date: Date(), duration: 0, volume: 0, entries: [])
+        featuredExercises = GymSampleData.featuredExercises
+    }
+
+    func applyRoutine(_ routine: Routine) {
+        activeWorkout.entries = routine.dayPlans.flatMap { day in
+            day.exercises.map { exercise in
+                WorkoutEntry(exercise: exercise, sets: [WorkoutSet(weight: 0, reps: 8, kind: .regular)])
+            }
+        }
+        recalculateVolume()
+    }
+
+    func addExercise(_ exercise: Exercise) {
+        activeWorkout.entries.append(WorkoutEntry(exercise: exercise, sets: []))
+        recalculateVolume()
+    }
+
+    func addExerciseFromCatalog(_ exercise: Exercise) {
+        var sets: [WorkoutSet] = []
+        if let guidance = exercise.guidance {
+            let templateSet = WorkoutSet(weight: guidance.recommendedWeight ?? 0, reps: guidance.repsPerSet)
+            for _ in 0..<max(guidance.setCount, 1) {
+                sets.append(templateSet)
+            }
+        }
+        activeWorkout.entries.append(WorkoutEntry(exercise: exercise, sets: sets))
+        recalculateVolume()
+    }
+
+    func addSet(to entryID: UUID, set: WorkoutSet) {
+        guard let index = activeWorkout.entries.firstIndex(where: { $0.id == entryID }) else { return }
+        activeWorkout.entries[index].sets.append(set)
+        recalculateVolume()
+    }
+
+    func addRecommendedSet(to entryID: UUID) {
+        guard let entry = activeWorkout.entries.first(where: { $0.id == entryID }) else { return }
+        let set = defaultSet(for: entry.exercise)
+        addSet(to: entryID, set: set)
+    }
+
+    func removeEntry(_ entryID: UUID) {
+        activeWorkout.entries.removeAll { $0.id == entryID }
+        recalculateVolume()
+    }
+
+    func save() {
+        Task {
+            do {
+                isSaving = true
+                try await logWorkoutUseCase.execute(activeWorkout)
+                saveError = nil
+            } catch {
+                saveError = error.localizedDescription
+            }
+            isSaving = false
+        }
+    }
+
+    func availableRoutines() async throws -> [Routine] {
+        try await routineRepository.routines()
+    }
+
+    private func recalculateVolume() {
+        activeWorkout.volume = activeWorkout.entries.reduce(0) { $0 + $1.totalVolume }
+    }
+
+    private func defaultSet(for exercise: Exercise) -> WorkoutSet {
+        if let guidance = exercise.guidance {
+            return WorkoutSet(weight: guidance.recommendedWeight ?? 0, reps: guidance.repsPerSet)
+        }
+        return WorkoutSet(weight: 20, reps: 8)
+    }
+}

--- a/Sources/App/GymApp.swift
+++ b/Sources/App/GymApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import Domain
+import Persistence
+import Health
+import AICore
+
+@main
+struct GymApp: App {
+    @StateObject private var container = AppContainer()
+
+    var body: some Scene {
+        WindowGroup {
+            GymTabView()
+                .environmentObject(container.dashboardViewModel)
+                .environmentObject(container.workoutViewModel)
+                .environmentObject(container.progressViewModel)
+                .environmentObject(container.aiCoachViewModel)
+        }
+    }
+}

--- a/Sources/App/Shared/AppContainer.swift
+++ b/Sources/App/Shared/AppContainer.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Combine
+import Domain
+import Persistence
+import Health
+import AICore
+
+@MainActor
+final class AppContainer: ObservableObject {
+    let workoutRepository: WorkoutRepository
+    let routineRepository: RoutineRepository
+    let bodyMetricRepository: BodyMetricRepository
+    let aiInsightRepository: AIInsightRepository
+    let aiRecommender: AIRecommender
+
+    let dashboardViewModel: DashboardViewModel
+    let workoutViewModel: WorkoutLoggingViewModel
+    let progressViewModel: ProgressViewModel
+    let aiCoachViewModel: AICoachViewModel
+
+    init() {
+        let workoutRepository = WorkoutRepositoryImpl()
+        let routineRepository = RoutineRepositoryImpl()
+        let bodyMetricRepository = BodyMetricRepositoryImpl()
+        let aiInsightRepository = AIInsightRepositoryImpl()
+        let aiRecommender = OfflineAIRecommender()
+
+        self.workoutRepository = workoutRepository
+        self.routineRepository = routineRepository
+        self.bodyMetricRepository = bodyMetricRepository
+        self.aiInsightRepository = aiInsightRepository
+        self.aiRecommender = aiRecommender
+
+        dashboardViewModel = DashboardViewModel(workoutRepository: workoutRepository, aiInsightRepository: aiInsightRepository)
+        workoutViewModel = WorkoutLoggingViewModel(logWorkoutUseCase: LogWorkoutUseCase(workoutRepository: workoutRepository), routineRepository: routineRepository)
+        progressViewModel = ProgressViewModel(fetchProgressSummaryUseCase: FetchProgressSummaryUseCase(workoutRepository: workoutRepository, bodyMetricRepository: bodyMetricRepository))
+        aiCoachViewModel = AICoachViewModel(generateAIInsightUseCase: GenerateAIInsightUseCase(workoutRepository: workoutRepository, bodyMetricRepository: bodyMetricRepository, recommender: aiRecommender, aiInsightRepository: aiInsightRepository))
+    }
+}

--- a/Sources/App/Shared/FlowLayout.swift
+++ b/Sources/App/Shared/FlowLayout.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct FlowLayout<Content: View>: View {
+    var spacing: CGFloat
+    @ViewBuilder var content: Content
+
+    init(spacing: CGFloat = 8, @ViewBuilder content: () -> Content) {
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        FlowLayoutLayout(spacing: spacing) {
+            content
+        }
+    }
+}
+
+private struct FlowLayoutLayout: Layout {
+    var spacing: CGFloat
+
+    init(spacing: CGFloat) {
+        self.spacing = spacing
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth {
+                currentX = 0
+                currentY += rowHeight + spacing
+                rowHeight = 0
+            }
+            totalWidth = max(totalWidth, currentX + size.width)
+            rowHeight = max(rowHeight, size.height)
+            currentX += size.width + spacing
+        }
+
+        return CGSize(width: totalWidth, height: currentY + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var currentX = bounds.minX
+        var currentY = bounds.minY
+        var rowHeight: CGFloat = 0
+        let maxWidth = bounds.width
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > bounds.minX + maxWidth {
+                currentX = bounds.minX
+                currentY += rowHeight + spacing
+                rowHeight = 0
+            }
+
+            subview.place(at: CGPoint(x: currentX, y: currentY), proposal: ProposedViewSize(width: size.width, height: size.height))
+            currentX += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/Sources/App/Shared/GymCard.swift
+++ b/Sources/App/Shared/GymCard.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct GymCard<Content: View>: View {
+    let title: String
+    let icon: String?
+    @ViewBuilder let content: Content
+
+    init(title: String, icon: String? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.icon = icon
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if !title.isEmpty {
+                HStack(spacing: 10) {
+                    if let icon {
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .foregroundStyle(.accent)
+                    }
+                    Text(title)
+                        .font(.title3.bold())
+                    Spacer()
+                }
+            }
+
+            content
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .shadow(color: Color.black.opacity(0.08), radius: 16, x: 0, y: 8)
+        )
+    }
+}

--- a/Sources/App/Shared/GymTabView.swift
+++ b/Sources/App/Shared/GymTabView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct GymTabView: View {
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Label("Főoldal", systemImage: "figure.strengthtraining.traditional")
+                }
+            WorkoutLoggingView()
+                .tabItem {
+                    Label("Edzés", systemImage: "plus.square.on.square")
+                }
+            ProgressViewScreen()
+                .tabItem {
+                    Label("Haladás", systemImage: "chart.line.uptrend.xyaxis")
+                }
+            AICoachView()
+                .tabItem {
+                    Label("AI Edző", systemImage: "brain")
+                }
+        }
+    }
+}

--- a/Sources/App/Shared/TagCloud.swift
+++ b/Sources/App/Shared/TagCloud.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import Domain
+
+struct TagCloud: View {
+    let tags: [AIInsight.InsightKind]
+
+    var body: some View {
+        FlowLayout(spacing: 8) {
+            ForEach(tags, id: \.self) { tag in
+                Text(label(for: tag))
+                    .font(.caption)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(Color.accentColor.opacity(0.12)))
+            }
+        }
+    }
+
+    private func label(for tag: AIInsight.InsightKind) -> String {
+        switch tag {
+        case .motivation: return "Motiváció"
+        case .recommendation: return "Ajánlás"
+        case .warning: return "Figyelmeztetés"
+        case .deloadSuggestion: return "Deload"
+        }
+    }
+}

--- a/Sources/AppIntents/LogWorkoutIntent.swift
+++ b/Sources/AppIntents/LogWorkoutIntent.swift
@@ -1,0 +1,28 @@
+#if canImport(AppIntents)
+import AppIntents
+import Domain
+import Persistence
+
+struct QuickLogWorkoutIntent: AppIntent {
+    static var title: LocalizedStringResource = "Gyors edzés rögzítése"
+
+    @Parameter(title: "Gyakorlat neve")
+    var exerciseName: String
+
+    @Parameter(title: "Ismétlések")
+    var reps: Int
+
+    @Parameter(title: "Súly (kg)")
+    var weight: Double
+
+    func perform() async throws -> some IntentResult {
+        let exercise = Exercise(name: exerciseName, kind: .dumbbell, primaryMuscles: [.fullBody])
+        let set = WorkoutSet(weight: weight, reps: reps)
+        let entry = WorkoutEntry(exercise: exercise, sets: [set])
+        let workout = Workout(date: .init(), duration: 1200, volume: entry.totalVolume, entries: [entry])
+        let useCase = LogWorkoutUseCase(workoutRepository: WorkoutRepositoryImpl())
+        try await useCase.execute(workout)
+        return .result(value: "Rögzítve")
+    }
+}
+#endif

--- a/Sources/Domain/Entities/AIInsight.swift
+++ b/Sources/Domain/Entities/AIInsight.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public struct AIInsight: Identifiable, Codable, Hashable {
+    public enum InsightKind: String, Codable {
+        case motivation
+        case recommendation
+        case warning
+        case deloadSuggestion
+    }
+
+    public let id: UUID
+    public var workoutID: UUID
+    public var createdAt: Date
+    public var motivationText: String
+    public var recommendationText: String
+    public var tags: [InsightKind]
+    public var appliedChanges: [RoutineChange]
+
+    public init(
+        id: UUID = UUID(),
+        workoutID: UUID,
+        createdAt: Date = .init(),
+        motivationText: String,
+        recommendationText: String,
+        tags: [InsightKind] = [],
+        appliedChanges: [RoutineChange] = []
+    ) {
+        self.id = id
+        self.workoutID = workoutID
+        self.createdAt = createdAt
+        self.motivationText = motivationText
+        self.recommendationText = recommendationText
+        self.tags = tags
+        self.appliedChanges = appliedChanges
+    }
+}
+
+public struct RoutineChange: Identifiable, Codable, Hashable {
+    public enum ChangeKind: String, Codable {
+        case increaseWeight
+        case increaseReps
+        case adjustSets
+        case introduceSuperset
+        case scheduleDeload
+        case adjustRest
+    }
+
+    public let id: UUID
+    public var exerciseID: UUID?
+    public var description: String
+    public var changeKind: ChangeKind
+    public var metadata: [String: String]
+
+    public init(
+        id: UUID = UUID(),
+        exerciseID: UUID? = nil,
+        description: String,
+        changeKind: ChangeKind,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.exerciseID = exerciseID
+        self.description = description
+        self.changeKind = changeKind
+        self.metadata = metadata
+    }
+}

--- a/Sources/Domain/Entities/BodyMetric.swift
+++ b/Sources/Domain/Entities/BodyMetric.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct BodyMetric: Identifiable, Codable, Hashable {
+    public enum Kind: String, Codable, CaseIterable {
+        case weight
+        case bodyFat
+        case chestCircumference
+        case waistCircumference
+        case hipCircumference
+        case armCircumference
+        case thighCircumference
+        case calfCircumference
+    }
+
+    public let id: UUID
+    public var kind: Kind
+    public var value: Double
+    public var unit: String
+    public var date: Date
+    public var note: String?
+
+    public init(
+        id: UUID = UUID(),
+        kind: Kind,
+        value: Double,
+        unit: String,
+        date: Date = .init(),
+        note: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.value = value
+        self.unit = unit
+        self.date = date
+        self.note = note
+    }
+}

--- a/Sources/Domain/Entities/Exercise.swift
+++ b/Sources/Domain/Entities/Exercise.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public struct Exercise: Identifiable, Hashable, Codable {
+    public struct Guidance: Hashable, Codable {
+        public var goal: String
+        public var recommendedWeight: Double?
+        public var setCount: Int
+        public var repsPerSet: Int
+        public var perSide: Bool
+        public var detailedDescription: String
+        public var videoURL: URL?
+        public var mediaURL: URL?
+
+        public init(
+            goal: String,
+            recommendedWeight: Double? = nil,
+            setCount: Int,
+            repsPerSet: Int,
+            perSide: Bool = false,
+            detailedDescription: String,
+            videoURL: URL? = nil,
+            mediaURL: URL? = nil
+        ) {
+            self.goal = goal
+            self.recommendedWeight = recommendedWeight
+            self.setCount = setCount
+            self.repsPerSet = repsPerSet
+            self.perSide = perSide
+            self.detailedDescription = detailedDescription
+            self.videoURL = videoURL
+            self.mediaURL = mediaURL
+        }
+    }
+
+    public enum Kind: String, Codable, CaseIterable {
+        case barbell
+        case dumbbell
+        case machine
+        case bodyweight
+        case cable
+        case kettlebell
+        case resistanceBand
+        case cardio
+        case mobility
+    }
+
+    public let id: UUID
+    public var name: String
+    public var kind: Kind
+    public var primaryMuscles: [MuscleGroup]
+    public var secondaryMuscles: [MuscleGroup]
+    public var instructions: String?
+    public var guidance: Guidance?
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        kind: Kind,
+        primaryMuscles: [MuscleGroup],
+        secondaryMuscles: [MuscleGroup] = [],
+        instructions: String? = nil,
+        guidance: Guidance? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.kind = kind
+        self.primaryMuscles = primaryMuscles
+        self.secondaryMuscles = secondaryMuscles
+        self.instructions = instructions
+        self.guidance = guidance
+    }
+}
+
+public extension Exercise.Guidance {
+    var recommendedWeightText: String {
+        guard let recommendedWeight else { return "-" }
+        if recommendedWeight.truncatingRemainder(dividingBy: 1) == 0 {
+            return "\(Int(recommendedWeight)) kg"
+        }
+        return String(format: "%.1f kg", recommendedWeight)
+    }
+
+    var setSummaryText: String {
+        let base = "\(setCount) × \(repsPerSet) ismétlés"
+        return perSide ? base + " karonként" : base
+    }
+}

--- a/Sources/Domain/Entities/Routine.swift
+++ b/Sources/Domain/Entities/Routine.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public struct Routine: Identifiable, Hashable, Codable {
+    public struct DayPlan: Identifiable, Hashable, Codable {
+        public let id: UUID
+        public var name: String
+        public var muscleFocus: [MuscleGroup]
+        public var exercises: [Exercise]
+        public var notes: String?
+
+        public init(
+            id: UUID = UUID(),
+            name: String,
+            muscleFocus: [MuscleGroup],
+            exercises: [Exercise],
+            notes: String? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.muscleFocus = muscleFocus
+            self.exercises = exercises
+            self.notes = notes
+        }
+    }
+
+    public let id: UUID
+    public var name: String
+    public var description: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var dayPlans: [DayPlan]
+    public var source: Workout.Source
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        description: String,
+        createdAt: Date = .init(),
+        updatedAt: Date = .init(),
+        dayPlans: [DayPlan],
+        source: Workout.Source = .manual
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.dayPlans = dayPlans
+        self.source = source
+    }
+}

--- a/Sources/Domain/Entities/Workout.swift
+++ b/Sources/Domain/Entities/Workout.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public struct Workout: Identifiable, Hashable, Codable {
+    public enum Source: String, Codable {
+        case manual
+        case routine
+        case aiGenerated
+    }
+
+    public let id: UUID
+    public var date: Date
+    public var duration: TimeInterval
+    public var volume: Double
+    public var averageHeartRate: Double?
+    public var maxHeartRate: Double?
+    public var recoveryTimeMinutes: Int?
+    public var notes: String?
+    public var entries: [WorkoutEntry]
+    public var source: Source
+
+    public init(
+        id: UUID = UUID(),
+        date: Date = .init(),
+        duration: TimeInterval = 0,
+        volume: Double = 0,
+        averageHeartRate: Double? = nil,
+        maxHeartRate: Double? = nil,
+        recoveryTimeMinutes: Int? = nil,
+        notes: String? = nil,
+        entries: [WorkoutEntry] = [],
+        source: Source = .manual
+    ) {
+        self.id = id
+        self.date = date
+        self.duration = duration
+        self.volume = volume
+        self.averageHeartRate = averageHeartRate
+        self.maxHeartRate = maxHeartRate
+        self.recoveryTimeMinutes = recoveryTimeMinutes
+        self.notes = notes
+        self.entries = entries
+        self.source = source
+    }
+}
+
+public extension Workout {
+    var musclesTargeted: Set<MuscleGroup> {
+        Set(entries.flatMap { $0.exercise.primaryMuscles + $0.exercise.secondaryMuscles })
+    }
+
+    var totalSets: Int {
+        entries.reduce(into: 0) { result, entry in
+            result += entry.sets.count
+        }
+    }
+}

--- a/Sources/Domain/SampleData/GymSampleData.swift
+++ b/Sources/Domain/SampleData/GymSampleData.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public enum GymSampleData {
+    public static let singleArmChestPress = Exercise(
+        name: "Egykezes mellnyomás fekve",
+        kind: .dumbbell,
+        primaryMuscles: [.chest],
+        secondaryMuscles: [.triceps, .shoulders],
+        instructions: """
+Cél: mellizom, tricepsz, váll
+Súly: 16 kg
+Sorozat: 3 × 10 ismétlés karonként
+Leírás: Hanyatt fekve nyomd fel a súlyt, könyököt enyhén oldalra engedve. Kézfej lehet kissé befelé fordítva.
+""",
+        guidance: .init(
+            goal: "Mellizom, tricepsz, váll",
+            recommendedWeight: 16,
+            setCount: 3,
+            repsPerSet: 10,
+            perSide: true,
+            detailedDescription: "Hanyatt fekve nyomd fel a súlyt, könyököt enyhén oldalra engedve. Kézfej lehet kissé befelé fordítva.",
+            videoURL: URL(string: "https://www.youtube.com/watch?v=Ad9mRbPt1D8"),
+            mediaURL: URL(string: "https://musclewiki.com/media/uploads/dumbbell-one-arm-bench-press-male.gif")
+        )
+    )
+
+    public static let sampleRoutine: Routine = {
+        Routine(
+            name: "Mell fókuszú minta",
+            description: "Egykezes mellnyomás fekve variáció a mell, tricepsz és vállak aktiválására.",
+            dayPlans: [
+                Routine.DayPlan(
+                    name: "Felsőtest erő",
+                    muscleFocus: [.chest, .triceps, .shoulders],
+                    exercises: [singleArmChestPress],
+                    notes: "Használd a javasolt terhelést és ismétlésszámot oldalanként."
+                )
+            ],
+            source: .routine
+        )
+    }()
+
+    public static let featuredExercises: [Exercise] = [singleArmChestPress]
+}

--- a/Sources/Domain/UseCases/AIUseCases.swift
+++ b/Sources/Domain/UseCases/AIUseCases.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public protocol AIRecommender {
+    func generateInsight(for workout: Workout, history: [Workout], metrics: [BodyMetric]) async throws -> AIInsight
+}
+
+public struct GenerateAIInsightUseCase {
+    private let workoutRepository: WorkoutRepository
+    private let bodyMetricRepository: BodyMetricRepository
+    private let recommender: AIRecommender
+    private let aiInsightRepository: AIInsightRepository
+
+    public init(
+        workoutRepository: WorkoutRepository,
+        bodyMetricRepository: BodyMetricRepository,
+        recommender: AIRecommender,
+        aiInsightRepository: AIInsightRepository
+    ) {
+        self.workoutRepository = workoutRepository
+        self.bodyMetricRepository = bodyMetricRepository
+        self.recommender = recommender
+        self.aiInsightRepository = aiInsightRepository
+    }
+
+    public func execute(for workout: Workout) async throws -> AIInsight {
+        let historyInterval = DateInterval(start: Calendar.current.date(byAdding: .day, value: -42, to: workout.date) ?? workout.date, end: workout.date)
+        let history = try await workoutRepository.workouts(between: historyInterval.start, and: historyInterval.end)
+        let metrics = try await bodyMetricRepository.metrics(of: .weight, limit: 12)
+        let insight = try await recommender.generateInsight(for: workout, history: history, metrics: metrics)
+        try await aiInsightRepository.save(insight)
+        return insight
+    }
+}

--- a/Sources/Domain/UseCases/WorkoutLoggingUseCases.swift
+++ b/Sources/Domain/UseCases/WorkoutLoggingUseCases.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+public protocol WorkoutRepository {
+    func save(_ workout: Workout) async throws
+    func latestWorkout(for exerciseID: UUID) async throws -> Workout?
+    func workouts(between startDate: Date, and endDate: Date) async throws -> [Workout]
+}
+
+public protocol RoutineRepository {
+    func routines() async throws -> [Routine]
+    func save(_ routine: Routine) async throws
+    func update(_ routine: Routine) async throws
+}
+
+public protocol BodyMetricRepository {
+    func save(_ metric: BodyMetric) async throws
+    func metrics(of kind: BodyMetric.Kind, limit: Int) async throws -> [BodyMetric]
+}
+
+public protocol AIInsightRepository {
+    func save(_ insight: AIInsight) async throws
+    func latestInsight() async throws -> AIInsight?
+}
+
+public struct LogWorkoutUseCase {
+    private let workoutRepository: WorkoutRepository
+
+    public init(workoutRepository: WorkoutRepository) {
+        self.workoutRepository = workoutRepository
+    }
+
+    public func execute(_ workout: Workout) async throws {
+        try await workoutRepository.save(workout)
+    }
+}
+
+public struct FetchProgressSummaryUseCase {
+    private let workoutRepository: WorkoutRepository
+    private let bodyMetricRepository: BodyMetricRepository
+
+    public init(
+        workoutRepository: WorkoutRepository,
+        bodyMetricRepository: BodyMetricRepository
+    ) {
+        self.workoutRepository = workoutRepository
+        self.bodyMetricRepository = bodyMetricRepository
+    }
+
+    public func execute(for interval: DateInterval) async throws -> ProgressSummary {
+        let workouts = try await workoutRepository.workouts(between: interval.start, and: interval.end)
+        let weightMetrics = try await bodyMetricRepository.metrics(of: .weight, limit: 30)
+        return ProgressSummary(workouts: workouts, weightMetrics: weightMetrics)
+    }
+}
+
+public struct SaveAIInsightUseCase {
+    private let repository: AIInsightRepository
+
+    public init(repository: AIInsightRepository) {
+        self.repository = repository
+    }
+
+    public func execute(_ insight: AIInsight) async throws {
+        try await repository.save(insight)
+    }
+}
+
+public struct ProgressSummary: Hashable {
+    public let totalVolume: Double
+    public let averageIntensity: Double
+    public let workoutCount: Int
+    public let latestWeight: Double?
+    public let volumeByMuscleGroup: [MuscleGroup: Double]
+
+    public init(workouts: [Workout], weightMetrics: [BodyMetric]) {
+        workoutCount = workouts.count
+        totalVolume = workouts.reduce(0) { $0 + $1.volume }
+        if workoutCount > 0 {
+            let intensity = workouts.compactMap { workout -> Double? in
+                guard workout.totalSets > 0 else { return nil }
+                return workout.volume / Double(workout.totalSets)
+            }
+            averageIntensity = intensity.reduce(0, +) / Double(intensity.count)
+        } else {
+            averageIntensity = 0
+        }
+        latestWeight = weightMetrics.sorted(by: { $0.date > $1.date }).first?.value
+        volumeByMuscleGroup = workouts.reduce(into: [:]) { partialResult, workout in
+            let entries = workout.entries
+            entries.forEach { entry in
+                let volume = entry.totalVolume
+                entry.exercise.primaryMuscles.forEach { partialResult[$0, default: 0] += volume }
+                entry.exercise.secondaryMuscles.forEach { partialResult[$0, default: 0] += volume * 0.5 }
+            }
+        }
+    }
+}

--- a/Sources/Domain/ValueObjects/MuscleGroup.swift
+++ b/Sources/Domain/ValueObjects/MuscleGroup.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public enum MuscleGroup: String, CaseIterable, Codable, Hashable, Identifiable {
+    case chest
+    case back
+    case shoulders
+    case biceps
+    case triceps
+    case forearms
+    case core
+    case quadriceps
+    case hamstrings
+    case glutes
+    case calves
+    case fullBody
+    case cardio
+    case mobility
+
+    public var id: String { rawValue }
+
+    public var localizedName: String {
+        switch self {
+        case .chest: return "Mell"
+        case .back: return "Hát"
+        case .shoulders: return "Váll"
+        case .biceps: return "Bicepsz"
+        case .triceps: return "Tricepsz"
+        case .forearms: return "Alkar"
+        case .core: return "Törzs"
+        case .quadriceps: return "Combfeszítő"
+        case .hamstrings: return "Combhajlító"
+        case .glutes: return "Farizom"
+        case .calves: return "Vádli"
+        case .fullBody: return "Teljes test"
+        case .cardio: return "Kardió"
+        case .mobility: return "Mobilitás"
+        }
+    }
+}

--- a/Sources/Domain/ValueObjects/WorkoutEntry.swift
+++ b/Sources/Domain/ValueObjects/WorkoutEntry.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct WorkoutEntry: Identifiable, Hashable, Codable {
+    public let id: UUID
+    public var exercise: Exercise
+    public var sets: [WorkoutSet]
+    public var restTime: TimeInterval?
+    public var isWarmup: Bool
+
+    public init(
+        id: UUID = UUID(),
+        exercise: Exercise,
+        sets: [WorkoutSet],
+        restTime: TimeInterval? = nil,
+        isWarmup: Bool = false
+    ) {
+        self.id = id
+        self.exercise = exercise
+        self.sets = sets
+        self.restTime = restTime
+        self.isWarmup = isWarmup
+    }
+}
+
+public extension WorkoutEntry {
+    var totalVolume: Double {
+        sets.reduce(0) { $0 + $1.volume }
+    }
+}

--- a/Sources/Domain/ValueObjects/WorkoutSet.swift
+++ b/Sources/Domain/ValueObjects/WorkoutSet.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public struct WorkoutSet: Identifiable, Hashable, Codable {
+    public enum SetKind: String, Codable {
+        case regular
+        case drop
+        case amrap
+        case failure
+        case warmup
+        case cooldown
+        case cluster
+    }
+
+    public let id: UUID
+    public var weight: Double
+    public var reps: Int
+    public var rpe: Double?
+    public var notes: String?
+    public var kind: SetKind
+
+    public init(
+        id: UUID = UUID(),
+        weight: Double,
+        reps: Int,
+        rpe: Double? = nil,
+        notes: String? = nil,
+        kind: SetKind = .regular
+    ) {
+        self.id = id
+        self.weight = weight
+        self.reps = reps
+        self.rpe = rpe
+        self.notes = notes
+        self.kind = kind
+    }
+}
+
+public extension WorkoutSet {
+    var volume: Double {
+        weight * Double(reps)
+    }
+}

--- a/Sources/Health/HealthKitGateway.swift
+++ b/Sources/Health/HealthKitGateway.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Domain
+
+#if canImport(HealthKit)
+import HealthKit
+
+public final class HealthKitGateway {
+    private let healthStore = HKHealthStore()
+
+    public init() {}
+
+    public func requestAuthorization() async throws {
+        let workoutType = HKObjectType.workoutType()
+        let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate)!
+        try await healthStore.requestAuthorization(toShare: [workoutType], read: [workoutType, heartRateType])
+    }
+
+    public func fetchHeartRateSummary(for workout: Workout) async throws -> HeartRateSummary {
+        let predicate = HKQuery.predicateForSamples(withStart: workout.date, end: workout.date.addingTimeInterval(workout.duration))
+        let descriptor = HKStatisticsQueryDescriptor(predicate: predicate, options: [.discreteAverage, .discreteMax])
+        let result = try await descriptor.result(for: .quantityType(forIdentifier: .heartRate)!)
+        let average = result.averageQuantity()?.doubleValue(for: HKUnit.count().unitDivided(by: HKUnit.minute()))
+        let max = result.maximumQuantity()?.doubleValue(for: HKUnit.count().unitDivided(by: HKUnit.minute()))
+        return HeartRateSummary(average: average ?? 0, maximum: max ?? 0)
+    }
+}
+#else
+public final class HealthKitGateway {
+    public init() {}
+    public func requestAuthorization() async throws {}
+    public func fetchHeartRateSummary(for workout: Workout) async throws -> HeartRateSummary {
+        HeartRateSummary(average: 0, maximum: 0)
+    }
+}
+#endif
+
+public struct HeartRateSummary: Sendable {
+    public let average: Double
+    public let maximum: Double
+}

--- a/Sources/Persistence/Migrations/README.md
+++ b/Sources/Persistence/Migrations/README.md
@@ -1,0 +1,3 @@
+# Migrációk
+
+A futásidejű migrációkat a `DatabaseManager` tartalmazza. Ez a könyvtár készen áll SQL fájlok fogadására, ha a jövőben szükség lesz rájuk.

--- a/Sources/Persistence/Repositories/AIInsightRepositoryImpl.swift
+++ b/Sources/Persistence/Repositories/AIInsightRepositoryImpl.swift
@@ -1,0 +1,31 @@
+import Foundation
+import GRDB
+import Domain
+
+public final class AIInsightRepositoryImpl: AIInsightRepository {
+    private let dbQueue: DatabaseQueue
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(dbQueue: DatabaseQueue = DatabaseManager.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    public func save(_ insight: AIInsight) async throws {
+        try await dbQueue.write { db in
+            let data = try encoder.encode(insight)
+            try db.execute(sql: "REPLACE INTO aiInsight (id, workoutID, createdAt, payload) VALUES (?, ?, ?, ?)",
+                           arguments: [insight.id.uuidString, insight.workoutID.uuidString, insight.createdAt, data])
+        }
+    }
+
+    public func latestInsight() async throws -> AIInsight? {
+        try await dbQueue.read { db in
+            let row = try Row.fetchOne(db, sql: "SELECT payload FROM aiInsight ORDER BY createdAt DESC LIMIT 1")
+            guard let data: Data = row?["payload"] else { return nil }
+            return try decoder.decode(AIInsight.self, from: data)
+        }
+    }
+}

--- a/Sources/Persistence/Repositories/BodyMetricRepositoryImpl.swift
+++ b/Sources/Persistence/Repositories/BodyMetricRepositoryImpl.swift
@@ -1,0 +1,33 @@
+import Foundation
+import GRDB
+import Domain
+
+public final class BodyMetricRepositoryImpl: BodyMetricRepository {
+    private let dbQueue: DatabaseQueue
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(dbQueue: DatabaseQueue = DatabaseManager.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    public func save(_ metric: BodyMetric) async throws {
+        try await dbQueue.write { db in
+            let data = try encoder.encode(metric)
+            try db.execute(sql: "REPLACE INTO bodyMetric (id, kind, value, unit, date, note, payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                           arguments: [metric.id.uuidString, metric.kind.rawValue, metric.value, metric.unit, metric.date, metric.note, data])
+        }
+    }
+
+    public func metrics(of kind: BodyMetric.Kind, limit: Int) async throws -> [BodyMetric] {
+        try await dbQueue.read { db in
+            let rows = try Row.fetchAll(db, sql: "SELECT payload FROM bodyMetric WHERE kind = ? ORDER BY date DESC LIMIT ?", arguments: [kind.rawValue, limit])
+            return try rows.compactMap { row in
+                guard let data: Data = row["payload"] else { throw PersistenceError.invalidData }
+                return try decoder.decode(BodyMetric.self, from: data)
+            }
+        }
+    }
+}

--- a/Sources/Persistence/Repositories/RoutineRepositoryImpl.swift
+++ b/Sources/Persistence/Repositories/RoutineRepositoryImpl.swift
@@ -1,0 +1,57 @@
+import Foundation
+import GRDB
+import Domain
+
+public final class RoutineRepositoryImpl: RoutineRepository {
+    private let dbQueue: DatabaseQueue
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(dbQueue: DatabaseQueue = DatabaseManager.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        seedDefaultRoutineIfNeeded()
+    }
+
+    public func routines() async throws -> [Routine] {
+        try await dbQueue.read { db in
+            let rows = try Row.fetchAll(db, sql: "SELECT payload FROM routine ORDER BY updatedAt DESC")
+            return try rows.map { row in
+                guard let data: Data = row["payload"] else { throw PersistenceError.invalidData }
+                return try decoder.decode(Routine.self, from: data)
+            }
+        }
+    }
+
+    public func save(_ routine: Routine) async throws {
+        try await persist(routine)
+    }
+
+    public func update(_ routine: Routine) async throws {
+        try await persist(routine)
+    }
+
+    private func persist(_ routine: Routine) async throws {
+        try await dbQueue.write { db in
+            let data = try encoder.encode(routine)
+            try db.execute(sql: "REPLACE INTO routine (id, name, description, createdAt, updatedAt, source, payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                           arguments: [routine.id.uuidString, routine.name, routine.description, routine.createdAt, routine.updatedAt, routine.source.rawValue, data])
+        }
+    }
+
+    private func seedDefaultRoutineIfNeeded() {
+        do {
+            try dbQueue.write { db in
+                let existingCount = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM routine") ?? 0
+                guard existingCount == 0 else { return }
+                let routine = GymSampleData.sampleRoutine
+                let data = try encoder.encode(routine)
+                try db.execute(sql: "INSERT INTO routine (id, name, description, createdAt, updatedAt, source, payload) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                               arguments: [routine.id.uuidString, routine.name, routine.description, routine.createdAt, routine.updatedAt, routine.source.rawValue, data])
+            }
+        } catch {
+            print("Routine seed failed: \(error)")
+        }
+    }
+}

--- a/Sources/Persistence/Repositories/WorkoutRepositoryImpl.swift
+++ b/Sources/Persistence/Repositories/WorkoutRepositoryImpl.swift
@@ -1,0 +1,56 @@
+import Foundation
+import GRDB
+import Domain
+
+public final class WorkoutRepositoryImpl: WorkoutRepository {
+    private let dbQueue: DatabaseQueue
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(dbQueue: DatabaseQueue = DatabaseManager.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    public func save(_ workout: Workout) async throws {
+        try await dbQueue.write { db in
+            let data = try encoder.encode(workout)
+            try db.execute(sql: "REPLACE INTO workout (id, date, duration, volume, averageHeartRate, maxHeartRate, recoveryTimeMinutes, notes, source, payload) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                           arguments: [
+                            workout.id.uuidString,
+                            workout.date,
+                            workout.duration,
+                            workout.volume,
+                            workout.averageHeartRate,
+                            workout.maxHeartRate,
+                            workout.recoveryTimeMinutes,
+                            workout.notes,
+                            workout.source.rawValue,
+                            data
+                           ])
+        }
+    }
+
+    public func latestWorkout(for exerciseID: UUID) async throws -> Workout? {
+        try await dbQueue.read { db in
+            let row = try Row.fetchOne(db, sql: "SELECT payload FROM workout ORDER BY date DESC LIMIT 1")
+            guard let data: Data = row?["payload"] else { return nil }
+            return try decoder.decode(Workout.self, from: data)
+        }
+    }
+
+    public func workouts(between startDate: Date, and endDate: Date) async throws -> [Workout] {
+        try await dbQueue.read { db in
+            let rows = try Row.fetchAll(db, sql: "SELECT payload FROM workout WHERE date BETWEEN ? AND ? ORDER BY date DESC", arguments: [startDate, endDate])
+            return try rows.map { row in
+                guard let data: Data = row["payload"] else { throw PersistenceError.invalidData }
+                return try decoder.decode(Workout.self, from: data)
+            }
+        }
+    }
+}
+
+public enum PersistenceError: Error {
+    case invalidData
+}

--- a/Sources/Persistence/Support/DatabaseManager.swift
+++ b/Sources/Persistence/Support/DatabaseManager.swift
@@ -1,0 +1,66 @@
+import Foundation
+import GRDB
+import Domain
+
+public final class DatabaseManager {
+    public static let shared = DatabaseManager()
+
+    public let dbQueue: DatabaseQueue
+
+    private init() {
+        let fileManager = FileManager.default
+        let baseURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        let dbURL = baseURL.appendingPathComponent("gym.sqlite")
+        dbQueue = try! DatabaseQueue(path: dbURL.path)
+        migrate()
+    }
+
+    private func migrate() {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("createWorkouts") { db in
+            try db.create(table: "workout") { table in
+                table.column("id", .text).primaryKey()
+                table.column("date", .datetime).notNull()
+                table.column("duration", .double).notNull()
+                table.column("volume", .double).notNull()
+                table.column("averageHeartRate", .double)
+                table.column("maxHeartRate", .double)
+                table.column("recoveryTimeMinutes", .integer)
+                table.column("notes", .text)
+                table.column("source", .text).notNull()
+                table.column("payload", .blob).notNull()
+            }
+        }
+        migrator.registerMigration("createBodyMetrics") { db in
+            try db.create(table: "bodyMetric") { table in
+                table.column("id", .text).primaryKey()
+                table.column("kind", .text).notNull()
+                table.column("value", .double).notNull()
+                table.column("unit", .text).notNull()
+                table.column("date", .datetime).notNull()
+                table.column("note", .text)
+                table.column("payload", .blob).notNull()
+            }
+        }
+        migrator.registerMigration("createAIInsights") { db in
+            try db.create(table: "aiInsight") { table in
+                table.column("id", .text).primaryKey()
+                table.column("workoutID", .text).notNull()
+                table.column("createdAt", .datetime).notNull()
+                table.column("payload", .blob).notNull()
+            }
+        }
+        migrator.registerMigration("createRoutines") { db in
+            try db.create(table: "routine") { table in
+                table.column("id", .text).primaryKey()
+                table.column("name", .text).notNull()
+                table.column("description", .text).notNull()
+                table.column("createdAt", .datetime).notNull()
+                table.column("updatedAt", .datetime).notNull()
+                table.column("source", .text).notNull()
+                table.column("payload", .blob).notNull()
+            }
+        }
+        try? migrator.migrate(dbQueue)
+    }
+}

--- a/Sources/WatchApp/Session/WorkoutSessionManager.swift
+++ b/Sources/WatchApp/Session/WorkoutSessionManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Domain
+
+#if canImport(WatchKit)
+import HealthKit
+import WatchKit
+
+final class WorkoutSessionManager: NSObject, ObservableObject, HKWorkoutSessionDelegate, HKLiveWorkoutBuilderDelegate {
+    @Published private(set) var state: HKWorkoutSessionState = .notStarted
+    @Published private(set) var heartRate: Double = 0
+
+    private let healthStore = HKHealthStore()
+    private var session: HKWorkoutSession?
+    private var builder: HKLiveWorkoutBuilder?
+
+    func startWorkout(activity: HKWorkoutActivityType) throws {
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = activity
+        configuration.locationType = .indoor
+
+        session = try HKWorkoutSession(healthStore: healthStore, configuration: configuration)
+        builder = session?.associatedWorkoutBuilder()
+        builder?.dataSource = HKLiveWorkoutDataSource(healthStore: healthStore, workoutConfiguration: configuration)
+        session?.delegate = self
+        builder?.delegate = self
+        session?.startActivity(with: .now)
+        builder?.beginCollection(withStart: .now) { _, _ in }
+    }
+
+    func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState, from fromState: HKWorkoutSessionState, date: Date) {
+        Task { @MainActor in
+            state = toState
+        }
+    }
+
+    func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
+        print("Workout session error: \(error)")
+    }
+
+    func workoutBuilder(_ workoutBuilder: HKLiveWorkoutBuilder, didCollectDataOf collectedTypes: Set<HKSampleType>) {
+        guard collectedTypes.contains(where: { $0 == HKQuantityType.quantityType(forIdentifier: .heartRate) }) else { return }
+        let statistics = workoutBuilder.statistics(for: .quantityType(forIdentifier: .heartRate)!)
+        let unit = HKUnit.count().unitDivided(by: .minute())
+        let value = statistics?.mostRecentQuantity()?.doubleValue(for: unit) ?? 0
+        Task { @MainActor in
+            heartRate = value
+        }
+    }
+
+    func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) {}
+}
+#else
+final class WorkoutSessionManager: ObservableObject {}
+#endif

--- a/Sources/WatchApp/Shared/WatchWorkoutView.swift
+++ b/Sources/WatchApp/Shared/WatchWorkoutView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct WatchWorkoutView: View {
+    @StateObject private var sessionManager = WorkoutSessionManager()
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Gym")
+                .font(.title2.bold())
+            Text("Pulzus: \(Int(sessionManager.heartRate)) bpm")
+                .font(.headline)
+            Button("Edzés indítása") {
+                #if canImport(WatchKit)
+                try? sessionManager.startWorkout(activity: .traditionalStrengthTraining)
+                #endif
+            }
+        }
+    }
+}

--- a/Tests/GymTests/ProgressSummaryTests.swift
+++ b/Tests/GymTests/ProgressSummaryTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Domain
+
+final class ProgressSummaryTests: XCTestCase {
+    func testProgressSummaryCalculatesVolumeAndSets() {
+        let exercise = Exercise(name: "Guggolás", kind: .barbell, primaryMuscles: [.quadriceps])
+        let entry = WorkoutEntry(exercise: exercise, sets: [WorkoutSet(weight: 100, reps: 5), WorkoutSet(weight: 120, reps: 3)])
+        let workout = Workout(date: Date(), duration: 3600, volume: entry.totalVolume, entries: [entry])
+        let summary = ProgressSummary(workouts: [workout], weightMetrics: [])
+        XCTAssertEqual(summary.totalVolume, entry.totalVolume)
+        XCTAssertEqual(summary.workoutCount, 1)
+        XCTAssertEqual(summary.volumeByMuscleGroup[.quadriceps], entry.totalVolume)
+    }
+}


### PR DESCRIPTION
## Summary
- redesign the dashboard, workout logging, progress, and AI coach screens with reusable GymCard styling optimized for iPhone
- extend the domain with guidance metadata, preload the single-arm chest press exercise, and seed a matching routine in persistence
- add shared UI components for card and tag layouts while exposing the featured exercise catalog inside the workout logger

## Testing
- swift test *(fails: unable to clone https://github.com/groue/GRDB.swift.git because the CONNECT tunnel returned 403)*

------
https://chatgpt.com/codex/tasks/task_b_68fe784fdde083288b5656c91aba7d2d